### PR TITLE
Command execution on difficulty change

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
                         <option>-ignorewarnings</option>
                     </options>
                     <libs>
-                        <lib>C:\Program Files\Java\jre1.8.0_341\lib\rt.jar</lib>
+                        <lib>${java.home}/lib/rt.jar</lib>
                     </libs>
                 </configuration>
                 <dependencies>

--- a/src/config.yml
+++ b/src/config.yml
@@ -134,6 +134,10 @@ disabled-mobs:
 #     <MythicMob>:
 #       replace-with: <Entity, replaces mob>
 #       chance-to-replace: <percentage, chance to replace a mob>
+#   execute: <Use %player% placeholder to customize>
+#     on-join: <list, commands to execute when a player with this difficulty joins the server>
+#     on-switch-from-next: <list, commands to execute when a player switches to this difficulty from the next one>
+#     on-switch-from-previous: <list, commands to execute when a player switches to this difficulty from the previous one>
 difficulty:
   Easy:
     enabled: true
@@ -171,6 +175,15 @@ difficulty:
       chest-chance: 75.0
       leggings-chance: 56.25
       boots-chance: 42.19
+    execute:
+      on-join:
+        # - '/minecraft:tellraw %player% "You are playing on EASY difficulty"'
+      on-switch-from-next:
+        # - '/minecraft:tellraw %player% "You are now playing on EASY difficulty"'
+        # - '/minecraft:tellraw %player% "Have a cookie for your troubles!"'
+        # - '/minecraft:give %player% minecraft:cookie 1'
+      # this line will be ignored if you don't have a previous difficulty
+      # on-switch-from-previous: []
   Normal:
     enabled: true
     affinity-required: 400
@@ -206,6 +219,13 @@ difficulty:
       SkeletalKnight:
         replace-with: SKELETON
         chance-to-replace: 1.0
+    execute:
+      on-join:
+        # - '/minecraft:tellraw %player% "You are playing on NORMAL difficulty"'
+      on-switch-from-next:
+        # - '/minecraft:tellraw %player% "You are now playing on NORMAL difficulty"'
+      on-switch-from-previous:
+        # - '/minecraft:tellraw %player% "You are now playing on NORMAL difficulty"'
   Hard:
     enabled: true
     affinity-required: 1100
@@ -246,6 +266,13 @@ difficulty:
       chest-chance: 90.0
       leggings-chance: 81.0
       boots-chance: 72.9
+    execute:
+      on-join:
+        # - '/minecraft:tellraw %player% "You are playing on HARD difficulty"'
+      on-switch-from-previous:
+        # - '/minecraft:tellraw @a "%player% has switched to HARD difficulty!"'
+      # This line will be ignored if you don't have a difficulty after this one
+      # on-switch-from-next: []
 
 custom-mob-items-spawn-chance:
   override-default-limits: false # will allow higher levels than Minecraft's defaults. (E.g. Unbreaking 7 can happen if max-level is higher or equals 7)

--- a/src/me/skinnyjeans/gmd/events/PlayerJoinListener.java
+++ b/src/me/skinnyjeans/gmd/events/PlayerJoinListener.java
@@ -2,8 +2,12 @@ package me.skinnyjeans.gmd.events;
 
 import me.skinnyjeans.gmd.managers.MainManager;
 import me.skinnyjeans.gmd.models.BaseListener;
+import me.skinnyjeans.gmd.models.Difficulty;
+import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.player.PlayerJoinEvent;
+
+import java.util.UUID;
 
 public class PlayerJoinListener extends BaseListener {
 
@@ -14,5 +18,15 @@ public class PlayerJoinListener extends BaseListener {
     }
 
     @EventHandler
-    public void onJoin(PlayerJoinEvent e) { MAIN_MANAGER.getPlayerManager().isPlayerValid(e.getPlayer()); }
+    public void onJoin(PlayerJoinEvent e) {
+        if (MAIN_MANAGER.getPlayerManager().isPlayerValid(e.getPlayer())) {
+            UUID uuid = e.getPlayer().getUniqueId();
+            Difficulty difficulty = MAIN_MANAGER.getDifficultyManager().getDifficulty(uuid);
+            Runnable afterJoinTask = () ->
+                    MAIN_MANAGER.getCommandManager()
+                            .dispatchCommandsIfOnline(uuid, difficulty.getCommandsOnJoin());
+
+            Bukkit.getScheduler().runTaskLater(MAIN_MANAGER.getPlugin(), afterJoinTask, 1L);
+        }
+    }
 }

--- a/src/me/skinnyjeans/gmd/managers/CommandManager.java
+++ b/src/me/skinnyjeans/gmd/managers/CommandManager.java
@@ -309,4 +309,30 @@ public class CommandManager implements CommandExecutor {
         DIFFICULTIES.clear();
         DIFFICULTIES.addAll(MAIN_MANAGER.getDifficultyManager().getDifficultyNames());
     }
+
+    private void dispatchCommandsInCurrentThread(UUID uuid, List<String> commands) {
+        Player player = Bukkit.getPlayer(uuid);
+        if (player == null) return;
+
+        try {
+            for (String command : commands) {
+                command = command.replace("%player%", player.getName());
+                if (command.startsWith("/")) command = command.substring(1);
+                boolean foundCommand = Bukkit.dispatchCommand(Bukkit.getConsoleSender(), command);
+                if (!foundCommand) {
+                    MAIN_MANAGER.getPlugin().getLogger().warning("Command not found: " + command);
+                    break;
+                }
+            }
+        } catch (Exception e) {
+            MAIN_MANAGER.getPlugin().getLogger().warning("Error dispatching commands for " + player.getName());
+            e.printStackTrace();
+        }
+    }
+
+    public void dispatchCommandsIfOnline(UUID uuid, List<String> commands) {
+        Bukkit.getScheduler().runTask(MAIN_MANAGER.getPlugin(), () ->
+            dispatchCommandsInCurrentThread(uuid, commands)
+        );
+    }
 }

--- a/src/me/skinnyjeans/gmd/models/Difficulty.java
+++ b/src/me/skinnyjeans/gmd/models/Difficulty.java
@@ -33,6 +33,9 @@ public class Difficulty {
     private boolean effectsWhenAttacked;
     private List<String> disabledCommands = new ArrayList<>();
     private List<String> mobsIgnoredPlayers = new ArrayList<>();
+    private List<String> commandsOnJoin = new ArrayList<>();
+    private List<String> commandsOnSwitchFromPrev = new ArrayList<>();
+    private List<String> commandsOnSwitchFromNext = new ArrayList<>();
     private List<MythicMobProfile> mythicMobProfiles = new ArrayList<>();
     private HashMap<EquipmentItems, Double> armorChance = new HashMap<>();
     private HashMap<ArmorTypes, Integer> armorDamageMultipliers = new HashMap<>();
@@ -72,6 +75,9 @@ public class Difficulty {
     public double getChanceToHaveWeapon() { return chanceToHaveWeapon; }
     public double getWeaponDropChance() { return weaponDropChance; }
     public double getChanceToCancelDeath() { return chanceCancelDeath; }
+    public List<String> getCommandsOnJoin() { return commandsOnJoin; }
+    public List<String> getCommandsOnSwitchFromPrev() { return commandsOnSwitchFromPrev; }
+    public List<String> getCommandsOnSwitchFromNext() { return commandsOnSwitchFromNext; }
 
     public void setPrefix(String value) { userPrefix = value; }
     public void setAffinity(int value) { affinityRequirement = value; }
@@ -104,4 +110,7 @@ public class Difficulty {
     public void setChanceToHaveArmor(Double value) { chanceToHaveArmor = value; }
     public void setChanceToHaveWeapon(Double value) { chanceToHaveWeapon = value; }
     public void setChanceToCancelDeath(Double value) { chanceCancelDeath = value; }
+    public void setCommandsOnJoin(List<String> value) { commandsOnJoin = value; }
+    public void setCommandsOnSwitchFromPrevious(List<String> value) { commandsOnSwitchFromPrev = value; }
+    public void setCommandsOnSwitchFromNext(List<String> value) { commandsOnSwitchFromNext = value; }
 }


### PR DESCRIPTION
Closes #12. Adds new fields to config with lists of commands to execute and runs them upon the changes in difficulty. I tested it locally, and it worked pretty well, let me know if I forget anything.

The only real design decision I consciously did, is to invoke all commands in a batch if the difficulty change is rapid. So, for example, if the player immediately goes from `Hard` to `Easy` (due to admin command or just being bad), the executor will stack the commands from both `Hard -> Normal` and `Normal -> Easy` transition and execute them all together.

I changed the `pom.xml` a little bit, and while I'm certain that it works on my machine, make sure to check it locally and revert the first commit if it no longer compiles. 

P.S. I was not able to compile it locally without modifying `pom.xml` further.