### PR TITLE
Affinity gain/loss caps per minute

### DIFF
--- a/src/config.yml
+++ b/src/config.yml
@@ -16,6 +16,15 @@ affinity-per-heart-loss: -1 # So 1.5 hearts of damage (counts as 2 hearts) amoun
 pve-kill: 2
 death: -100
 
+# How much affinity player can gain or lose every minute at most.
+# This is to prevent players from gaining too much affinity in a short amount of time,
+# for example, when using mob farms or killing themselves in a loop.
+# NOTE: If the momentary gain is higher than the max (or lower than the min),
+# the affinity gain WILL NOT BE CAPPED, so big gains, like from killing the boss or dying,
+# are still be possible. That's why if it is set to 0, the limitation does not apply.
+max-affinity-gain-per-minute: 0
+max-affinity-loss-per-minute: 0 # this value is expected to be negative
+
 # How Much Affinity a Player Starts With When Joining For The First Time.
 starting-affinity: 600
 

--- a/src/me/skinnyjeans/gmd/managers/AffinityManager.java
+++ b/src/me/skinnyjeans/gmd/managers/AffinityManager.java
@@ -18,8 +18,10 @@ public class AffinityManager {
 
         Bukkit.getScheduler().runTaskTimerAsynchronously(MAIN_MANAGER.getPlugin(), () ->
             Bukkit.getOnlinePlayers().forEach(player -> {
-                if (mainManager.getPlayerManager().isPlayerValid(player))
+                if (mainManager.getPlayerManager().isPlayerValid(player)) {
                     MAIN_MANAGER.getPlayerManager().addAffinity(player.getUniqueId(), intervalAffinity);
+                    MAIN_MANAGER.getPlayerManager().resetAllGainsThisMinute();
+                }
             }), 20 * 60, 20 * 60);
     }
 

--- a/src/me/skinnyjeans/gmd/models/Minecrafter.java
+++ b/src/me/skinnyjeans/gmd/models/Minecrafter.java
@@ -6,6 +6,7 @@ public class Minecrafter {
     private UUID uuid;
     private String name;
     private int affinity;
+    private int gainedThisMinute;
     private int minAffinity = -1;
     private int maxAffinity = -1;
 
@@ -19,10 +20,12 @@ public class Minecrafter {
     public int getAffinity() { return affinity; }
     public int getMinAffinity() { return minAffinity; }
     public int getMaxAffinity() { return maxAffinity; }
+    public int getGainedThisMinute() { return gainedThisMinute; }
 
     public void setUUID(UUID value) { uuid = value; }
     public void setName(String value) { name = value; }
     public void setAffinity(int value) { affinity = value; }
     public void setMinAffinity(int value) { minAffinity = value; }
     public void setMaxAffinity(int value) { maxAffinity = value; }
+    public void setGainedThisMinute(int value) { gainedThisMinute = value; }
 }


### PR DESCRIPTION
Another little feature I needed. This time, it's up to you whether to merge it or not because the explanation of the mechanic and the implementation details are questionable. I did it to prevent players who went to an enderman farm from getting a million for affinity for staying there for a few minutes. Basically, all it does is tracks how much affinity the player gained every minute and caps it at a certain amount. It only considers small gains like from mining and killing basic mobs, so the large effects of dying, or killing a boss are not affected at all. That way, even if the player kills hundreds of endermen in a minute, they will only get a few points. So even a player with 200 affinity can safely farm XP and expect to end up at 600 affinity at most, which is not that bad, considering the amount of XP they are potentially getting.

Looks ok on the surface, but then, there are a few nuances, and I'm not sure if it is worth documenting them, like "cap does not apply to big gains, but do those count toward the cap?" (no), or "does one big loss of health counts as one big loss or many tiny losses?" (first option), and so on.

I only implemented it because I need that mechanic, but I'm fine if it will not get into the final plugin. If you want, feel free to modify it however you desire.