### PR TITLE
Fix the reuse of mutable default player data

### DIFF
--- a/src/me/skinnyjeans/gmd/managers/PlayerManager.java
+++ b/src/me/skinnyjeans/gmd/managers/PlayerManager.java
@@ -28,7 +28,7 @@ public class PlayerManager {
                     MAIN_MANAGER.getDifficultyManager().calculateDifficulty(player.getUniqueId());
                 });
             } else {
-                Minecrafter playerData = MAIN_MANAGER.getAffinityManager().getDefault();
+                Minecrafter playerData = MAIN_MANAGER.getAffinityManager().getDefault().clone();
                 playerData.setName(player.getName());
                 playerData.setUUID(player.getUniqueId());
                 PLAYER_LIST.put(player.getUniqueId(), playerData);

--- a/src/me/skinnyjeans/gmd/models/Minecrafter.java
+++ b/src/me/skinnyjeans/gmd/models/Minecrafter.java
@@ -28,4 +28,15 @@ public class Minecrafter {
     public void setMinAffinity(int value) { minAffinity = value; }
     public void setMaxAffinity(int value) { maxAffinity = value; }
     public void setGainedThisMinute(int value) { gainedThisMinute = value; }
+
+    public Minecrafter clone() {
+        Minecrafter clone = new Minecrafter();
+        clone.setUUID(uuid);
+        clone.setName(name);
+        clone.setAffinity(affinity);
+        clone.setMinAffinity(minAffinity);
+        clone.setMaxAffinity(maxAffinity);
+        clone.setGainedThisMinute(gainedThisMinute);
+        return clone;
+    }
 }


### PR DESCRIPTION
A little bug I discovered: when a new player joins, if they get the affinity, the `defaultData` pseudo-player will also get the affinity (because it passed by a mutable reference and assigned), so the next time someone joins the affinity change of the player is inherited. I fixed that by cloning the `defaultData` and assigning a copy, instead of assigning the reference.